### PR TITLE
import re for line 18

### DIFF
--- a/lazynlp/utils.py
+++ b/lazynlp/utils.py
@@ -1,5 +1,6 @@
 import hashlib
 import os
+import re
 
 def dict_sorted_2_file(dictionary, file, reverse=True):
     with open(file, 'w') as out:


### PR DESCRIPTION
[flake8](http://flake8.pycqa.org) testing of https://github.com/chiphuyen/lazynlp on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./lazynlp/utils.py:17:12: F821 undefined name 're'
    return re.match("^([a-z]\.)+?$", token.lower()) is not None
           ^
1     F821 undefined name 're'
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree