### PR TITLE
ss18/pr0

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,4 +222,4 @@ So 1GB of text is about 181M words.
 3. The OpenAI dataset has 40GB, which I estimate to contain about 7-8 billion words.
 If you download all the webpages from the good Reddit URLs and Gutenberg books, you should have a dataset bigger than OpenAI's WebText.
 
-4. OpenAI, in their paper for GPT-2, didn't include Wikipedia artciles for fear of overlapping. You can choose to include Wikipedia articles that have less than a certain amount of overlapping with the existing dataset using ``lazynlp.estimate_overlap_bf(bf, target_file, gran='word', n=8``.
+4. OpenAI, in their paper for GPT-2, didn't include Wikipedia articles for fear of overlapping. You can choose to include Wikipedia articles that have less than a certain amount of overlapping with the existing dataset using ``lazynlp.estimate_overlap_bf(bf, target_file, gran='word', n=8``.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lazynlp
 
-A straightfoward library that allows you to crawl, clean up, and deduplicate webpages to create massive monolingual datasets. Using this library, you should be able to create datasets larger than the one used by OpenAI for GPT-2.
+A straightforward library that allows you to crawl, clean up, and deduplicate webpages to create massive monolingual datasets. Using this library, you should be able to create datasets larger than the one used by OpenAI for GPT-2.
 
 ## Setup
 This library uses Python 3.

--- a/lazynlp/cleaner.py
+++ b/lazynlp/cleaner.py
@@ -77,7 +77,7 @@ def connect_lines(txt, line_sep='\n'):
 
     This function is to connect those lines.
 
-    Two consecutive lines are seperated by line_sep.
+    Two consecutive lines are separated by line_sep.
     """
     lines = txt.split('\n')
 


### PR DESCRIPTION
Fixed typos:
seperated -> separated
artciles -> articles
straightfoward -> straightforward

Found with: https://github.com/ss18/grep-typos